### PR TITLE
[RFC] Example of cache refactoring

### DIFF
--- a/libraries/joomla/cache/controller.php
+++ b/libraries/joomla/cache/controller.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Public cache handler
  *
@@ -43,15 +45,6 @@ class JCacheController
 	{
 		$this->cache = new JCache($options);
 		$this->options = & $this->cache->_options;
-
-		// Overwrite default options with given options
-		foreach ($options as $option => $value)
-		{
-			if (isset($options[$option]))
-			{
-				$this->options[$option] = $options[$option];
-			}
-		}
 	}
 
 	/**
@@ -66,9 +59,7 @@ class JCacheController
 	 */
 	public function __call($name, $arguments)
 	{
-		$nazaj = call_user_func_array(array($this->cache, $name), $arguments);
-
-		return $nazaj;
+		return call_user_func_array(array($this->cache, $name), $arguments);
 	}
 
 	/**
@@ -97,12 +88,10 @@ class JCacheController
 
 			$path = JPath::find(self::addIncludePath(), strtolower($type) . '.php');
 
-			if ($path === false)
+			if ($path !== false)
 			{
-				throw new RuntimeException('Unable to load Cache Controller: ' . $type, 500);
+				include_once $path;
 			}
-
-			include_once $path;
 
 			// The class should now be loaded
 			if (!class_exists($class))
@@ -112,34 +101,6 @@ class JCacheController
 		}
 
 		return new $class($options);
-	}
-
-	/**
-	 * Set caching enabled state
-	 *
-	 * @param   boolean  $enabled  True to enable caching
-	 *
-	 * @return  void
-	 *
-	 * @since   11.1
-	 */
-	public function setCaching($enabled)
-	{
-		$this->cache->setCaching($enabled);
-	}
-
-	/**
-	 * Set cache lifetime
-	 *
-	 * @param   integer  $lt  Cache lifetime
-	 *
-	 * @return  void
-	 *
-	 * @since   11.1
-	 */
-	public function setLifeTime($lt)
-	{
-		$this->cache->setLifeTime($lt);
 	}
 
 	/**
@@ -178,6 +139,7 @@ class JCacheController
 	 * @return  mixed  Boolean false on no result, cached object otherwise
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0  Write own method in subclass
 	 */
 	public function get($id, $group = null)
 	{
@@ -185,24 +147,18 @@ class JCacheController
 
 		if ($data === false)
 		{
-			$locktest = $this->cache->lock($id, $group);
+			$lock = $this->cache->lock($id, $group);
 
-			if ($locktest->locked == true && $locktest->locklooped == true)
+			// If locklooped is true try to get the cached data again; it could exist now.
+			if ($lock->locked === true && $lock->locklooped === true)
 			{
 				$data = $this->cache->get($id, $group);
 			}
 
-			if ($locktest->locked == true)
+			if ($lock->locked === true)
 			{
 				$this->cache->unlock($id, $group);
 			}
-		}
-
-		// Check again because we might get it from second attempt
-		if ($data !== false)
-		{
-			// Trim to fix unserialize errors
-			$data = unserialize(trim($data));
 		}
 
 		return $data;
@@ -219,23 +175,264 @@ class JCacheController
 	 * @return  boolean  True if cache stored
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0  Write own method in subclass
 	 */
 	public function store($data, $id, $group = null, $wrkarounds = true)
 	{
-		$locktest = $this->cache->lock($id, $group);
+		$lock = $this->cache->lock($id, $group);
 
-		if ($locktest->locked == false && $locktest->locklooped == true)
+		if ($lock->locked === false)
 		{
-			$locktest = $this->cache->lock($id, $group);
+			// We can not store data because another process is in the middle of saving
+			return false;
 		}
 
-		$success = $this->cache->store(serialize($data), $id, $group);
+		$result = $this->cache->store($data, $id, $group);
 
-		if ($locktest->locked == true)
+		if ($lock->locked === true)
 		{
 			$this->cache->unlock($id, $group);
 		}
 
-		return $success;
+		return $result;
+	}
+
+	/**
+	 * Perform workarounds on retrieved cached data
+	 *
+	 * @param   string  $data     Cached data
+	 * @param   array   $options  Array of options
+	 *
+	 * @return  string  Body of cached data
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getWorkarounds($data, $options = array())
+	{
+		$app      = JFactory::getApplication();
+		$document = JFactory::getDocument();
+		$body     = null;
+
+		// Get the document head out of the cache.
+		if (isset($options['mergehead']) && $options['mergehead'] == 1 && isset($data['head']) && !empty($data['head'])
+			&& method_exists($document, 'mergeHeadData'))
+		{
+			$document->mergeHeadData($data['head']);
+		}
+		elseif (isset($data['head']) && method_exists($document, 'setHeadData'))
+		{
+			$document->setHeadData($data['head']);
+		}
+
+		// Get the document MIME encoding out of the cache
+		if (isset($data['mime_encoding']))
+		{
+			$document->setMimeEncoding($data['mime_encoding'], true);
+		}
+
+		// If the pathway buffer is set in the cache data, get it.
+		if (isset($data['pathway']) && is_array($data['pathway']))
+		{
+			// Push the pathway data into the pathway object.
+			$app->getPathway()->setPathway($data['pathway']);
+		}
+
+		// @todo check if the following is needed, seems like it should be in page cache
+		// If a module buffer is set in the cache data, get it.
+		if (isset($data['module']) && is_array($data['module']))
+		{
+			// Iterate through the module positions and push them into the document buffer.
+			foreach ($data['module'] as $name => $contents)
+			{
+				$document->setBuffer($contents, 'module', $name);
+			}
+		}
+
+		// Set cached headers.
+		if (isset($data['headers']) && $data['headers'])
+		{
+			foreach ($data['headers'] as $header)
+			{
+				$app->setHeader($header['name'], $header['value']);
+			}
+		}
+
+		// The following code searches for a token in the cached page and replaces it with the proper token.
+		if (isset($data['body']))
+		{
+			$token       = JSession::getFormToken();
+			$search      = '#<input type="hidden" name="[0-9a-f]{32}" value="1" />#';
+			$replacement = '<input type="hidden" name="' . $token . '" value="1" />';
+
+			$data['body'] = preg_replace($search, $replacement, $data['body']);
+			$body         = $data['body'];
+		}
+
+		// Get the document body out of the cache.
+		return $body;
+	}
+
+	/**
+	 * Create workarounds for data to be cached
+	 *
+	 * @param   string  $data     Cached data
+	 * @param   array   $options  Array of options
+	 *
+	 * @return  string  Data to be cached
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function setWorkarounds($data, $options = array())
+	{
+		$loptions = array(
+			'nopathway'  => 0,
+			'nohead'     => 0,
+			'nomodules'  => 0,
+			'modulemode' => 0,
+		);
+
+		if (isset($options['nopathway']))
+		{
+			$loptions['nopathway'] = $options['nopathway'];
+		}
+
+		if (isset($options['nohead']))
+		{
+			$loptions['nohead'] = $options['nohead'];
+		}
+
+		if (isset($options['nomodules']))
+		{
+			$loptions['nomodules'] = $options['nomodules'];
+		}
+
+		if (isset($options['modulemode']))
+		{
+			$loptions['modulemode'] = $options['modulemode'];
+		}
+
+		$app      = JFactory::getApplication();
+		$document = JFactory::getDocument();
+
+		if ($loptions['nomodules'] != 1)
+		{
+			// Get the modules buffer before component execution.
+			$buffer1 = $document->getBuffer();
+
+			if (!is_array($buffer1))
+			{
+				$buffer1 = array();
+			}
+
+			// Make sure the module buffer is an array.
+			if (!isset($buffer1['module']) || !is_array($buffer1['module']))
+			{
+				$buffer1['module'] = array();
+			}
+		}
+
+		// View body data
+		$cached['body'] = $data;
+
+		// Document head data
+		if ($loptions['nohead'] != 1 && method_exists($document, 'getHeadData'))
+		{
+			if ($loptions['modulemode'] == 1)
+			{
+				$headnow = $document->getHeadData();
+				$unset   = array('title', 'description', 'link', 'links', 'metaTags');
+
+				foreach ($unset as $un)
+				{
+					unset($headnow[$un]);
+					unset($options['headerbefore'][$un]);
+				}
+
+				$cached['head'] = array();
+
+				// Only store what this module has added
+				foreach ($headnow as $now => $value)
+				{
+					if (isset($options['headerbefore'][$now]))
+					{
+						// We have to serialize the content of the arrays because the may contain other arrays which is a notice in PHP 5.4 and newer
+						$nowvalue    = array_map('serialize', $headnow[$now]);
+						$beforevalue = array_map('serialize', $options['headerbefore'][$now]);
+
+						$newvalue = array_diff_assoc($nowvalue, $beforevalue);
+						$newvalue = array_map('unserialize', $newvalue);
+
+						// Special treatment for script and style declarations.
+						if (($now == 'script' || $now == 'style') && is_array($newvalue) && is_array($options['headerbefore'][$now]))
+						{
+							foreach ($newvalue as $type => $currentScriptStr)
+							{
+								if (isset($options['headerbefore'][$now][strtolower($type)]))
+								{
+									$oldScriptStr = $options['headerbefore'][$now][strtolower($type)];
+
+									if ($oldScriptStr != $currentScriptStr)
+									{
+										// Save only the appended declaration.
+										$newvalue[strtolower($type)] = StringHelper::substr($currentScriptStr, StringHelper::strlen($oldScriptStr));
+									}
+								}
+							}
+						}
+					}
+					else
+					{
+						$newvalue = $headnow[$now];
+					}
+
+					if (!empty($newvalue))
+					{
+						$cached['head'][$now] = $newvalue;
+					}
+				}
+			}
+			else
+			{
+				$cached['head'] = $document->getHeadData();
+			}
+		}
+
+		// Document MIME encoding
+		$cached['mime_encoding'] = $document->getMimeEncoding();
+
+		// Pathway data
+		if ($app->isSite() && $loptions['nopathway'] != 1)
+		{
+			$cached['pathway'] = is_array($data) && isset($data['pathway']) ? $data['pathway'] : $app->getPathway()->getPathway();
+		}
+
+		if ($loptions['nomodules'] != 1)
+		{
+			// @todo Check if the following is needed, seems like it should be in page cache
+			// Get the module buffer after component execution.
+			$buffer2 = $document->getBuffer();
+
+			if (!is_array($buffer2))
+			{
+				$buffer2 = array();
+			}
+
+			// Make sure the module buffer is an array.
+			if (!isset($buffer2['module']) || !is_array($buffer2['module']))
+			{
+				$buffer2['module'] = array();
+			}
+
+			// Compare the second module buffer against the first buffer.
+			$cached['module'] = array_diff_assoc($buffer2['module'], $buffer1['module']);
+		}
+
+		// Headers data
+		if (isset($options['headers']) && $options['headers'])
+		{
+			$cached['headers'] = $app->getHeaders();
+		}
+
+		return $cached;
 	}
 }

--- a/libraries/joomla/cache/controller/output.php
+++ b/libraries/joomla/cache/controller/output.php
@@ -37,6 +37,7 @@ class JCacheControllerOutput extends JCacheController
 	 *
 	 * @var    stdClass
 	 * @since  11.1
+	 * @deprecated  4.0
 	 */
 	protected $_locktest = null;
 
@@ -49,9 +50,16 @@ class JCacheControllerOutput extends JCacheController
 	 * @return  boolean
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0
 	 */
 	public function start($id, $group = null)
 	{
+		JLog::add(
+			__METHOD__ . '() is deprecated.',
+			JLog::WARNING,
+			'deprecated'
+		);
+
 		// If we have data in cache use that.
 		$data = $this->cache->get($id, $group);
 
@@ -71,7 +79,6 @@ class JCacheControllerOutput extends JCacheController
 
 		if ($data !== false)
 		{
-			$data = unserialize(trim($data));
 			echo $data;
 
 			if ($this->_locktest->locked == true)
@@ -104,9 +111,16 @@ class JCacheControllerOutput extends JCacheController
 	 * @return  boolean  True if the cache data was stored
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0
 	 */
 	public function end()
 	{
+		JLog::add(
+			__METHOD__ . '() is deprecated.',
+			JLog::WARNING,
+			'deprecated'
+		);
+
 		// Get data from output buffer and echo it
 		$data = ob_get_clean();
 		echo $data;
@@ -118,7 +132,7 @@ class JCacheControllerOutput extends JCacheController
 		$this->_group = null;
 
 		// Get the storage handler and store the cached data
-		$ret = $this->cache->store(serialize($data), $id, $group);
+		$ret = $this->cache->store($data, $id, $group);
 
 		if ($this->_locktest->locked == true)
 		{
@@ -126,5 +140,70 @@ class JCacheControllerOutput extends JCacheController
 		}
 
 		return $ret;
+	}
+
+	/**
+	 * Get stored cached data by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  mixed  Boolean false on no result, cached object otherwise
+	 *
+	 * @since   11.1
+	 */
+	public function get($id, $group = null)
+	{
+		$data = $this->cache->get($id, $group);
+
+		if ($data === false)
+		{
+			$lock = $this->cache->lock($id, $group);
+
+			// If locklooped is true try to get the cached data again; it could exist now.
+			if ($lock->locked === true && $lock->locklooped === true)
+			{
+				$data = $this->cache->get($id, $group);
+			}
+
+			if ($lock->locked === true)
+			{
+				$this->cache->unlock($id, $group);
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Store data to cache by ID and group
+	 *
+	 * @param   mixed    $data        The data to store
+	 * @param   string   $id          The cache data ID
+	 * @param   string   $group       The cache data group
+	 * @param   boolean  $wrkarounds  True to use wrkarounds
+	 *
+	 * @return  boolean  True if cache stored
+	 *
+	 * @since   11.1
+	 */
+	public function store($data, $id, $group = null, $wrkarounds = true)
+	{
+		$lock = $this->cache->lock($id, $group);
+
+		if ($lock->locked === false)
+		{
+			// We can not store data because another process is in the middle of saving
+			return false;
+		}
+
+		$result = $this->cache->store($data, $id, $group);
+
+		if ($lock->locked === true)
+		{
+			$this->cache->unlock($id, $group);
+		}
+
+		return $result;
 	}
 }

--- a/libraries/joomla/cache/controller/page.php
+++ b/libraries/joomla/cache/controller/page.php
@@ -53,7 +53,7 @@ class JCacheControllerPage extends JCacheController
 	public function get($id = false, $group = 'page')
 	{
 		// If an id is not given, generate it from the request
-		if ($id == false)
+		if (!$id)
 		{
 			$id = $this->_makeId();
 		}
@@ -77,15 +77,14 @@ class JCacheControllerPage extends JCacheController
 		// We got a cache hit... set the etag header and echo the page data
 		$data = $this->cache->get($id, $group);
 
-		$this->_locktest             = new stdClass;
-		$this->_locktest->locked     = null;
-		$this->_locktest->locklooped = null;
+		$this->_locktest = (object) array('locked' => null, 'locklooped' => null);
 
 		if ($data === false)
 		{
 			$this->_locktest = $this->cache->lock($id, $group);
 
-			if ($this->_locktest->locked == true && $this->_locktest->locklooped == true)
+			// If locklooped is true try to get the cached data again; it could exist now.
+			if ($this->_locktest->locked === true && $this->_locktest->locklooped === true)
 			{
 				$data = $this->cache->get($id, $group);
 			}
@@ -93,16 +92,14 @@ class JCacheControllerPage extends JCacheController
 
 		if ($data !== false)
 		{
-			$data = unserialize(trim($data));
-
-			$data = JCache::getWorkarounds($data);
-
-			$this->_setEtag($id);
-
-			if ($this->_locktest->locked == true)
+			if ($this->_locktest->locked === true)
 			{
 				$this->cache->unlock($id, $group);
 			}
+
+			$data = static::getWorkarounds($data);
+
+			$this->_setEtag($id);
 
 			return $data;
 		}
@@ -128,55 +125,56 @@ class JCacheControllerPage extends JCacheController
 	 */
 	public function store($data, $id, $group = null, $wrkarounds = true)
 	{
+		if ($this->_locktest->locked === false)
+		{
+			// We can not store data because another process is in the middle of saving
+			return false;
+		}
+
 		// Get page data from the application object
-		if (empty($data))
+		if (!$data)
 		{
 			$data = JFactory::getApplication()->getBody();
+
+			// Only attempt to store if page data exists.
+			if (!$data)
+			{
+				return false;
+			}
 		}
 
 		// Get id and group and reset the placeholders
-		if (empty($id))
+		if (!$id)
 		{
 			$id = $this->_id;
 		}
 
-		if (empty($group))
+		if (!$group)
 		{
 			$group = $this->_group;
 		}
 
-		// Only attempt to store if page data exists
-		if ($data)
+		if ($wrkarounds)
 		{
-			if ($wrkarounds)
-			{
-				$data = JCache::setWorkarounds(
-					$data,
-					array(
-						'nopathway' => 1,
-						'nohead'    => 1,
-						'nomodules' => 1,
-						'headers'   => true,
-					)
-				);
-			}
-
-			if ($this->_locktest->locked == false)
-			{
-				$this->_locktest = $this->cache->lock($id, $group);
-			}
-
-			$sucess = $this->cache->store(serialize($data), $id, $group);
-
-			if ($this->_locktest->locked == true)
-			{
-				$this->cache->unlock($id, $group);
-			}
-
-			return $sucess;
+			$data = static::setWorkarounds(
+				$data,
+				array(
+					'nopathway' => 1,
+					'nohead'    => 1,
+					'nomodules' => 1,
+					'headers'   => true,
+				)
+			);
 		}
 
-		return false;
+		$result = $this->cache->store($data, $id, $group);
+
+		if ($this->_locktest->locked === true)
+		{
+			$this->cache->unlock($id, $group);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/libraries/joomla/cache/controller/view.php
+++ b/libraries/joomla/cache/controller/view.php
@@ -31,26 +31,24 @@ class JCacheControllerView extends JCacheController
 	public function get($view, $method = 'display', $id = false, $wrkarounds = true)
 	{
 		// If an id is not given generate it from the request
-		if ($id == false)
+		if (!$id)
 		{
 			$id = $this->_makeId($view, $method);
 		}
 
 		$data = $this->cache->get($id);
 
-		$locktest             = new stdClass;
-		$locktest->locked     = null;
-		$locktest->locklooped = null;
+		$lock = (object) array('locked' => null, 'locklooped' => null);
 
 		if ($data === false)
 		{
-			$locktest = $this->cache->lock($id, null);
+			$lock = $this->cache->lock($id);
 
 			/*
 			 * If the loop is completed and returned true it means the lock has been set.
 			 * If looped is true try to get the cached data again; it could exist now.
 			 */
-			if ($locktest->locked == true && $locktest->locklooped == true)
+			if ($lock->locked === true && $lock->locklooped === true)
 			{
 				$data = $this->cache->get($id);
 			}
@@ -60,56 +58,61 @@ class JCacheControllerView extends JCacheController
 
 		if ($data !== false)
 		{
-			$data = unserialize(trim($data));
-
-			if ($wrkarounds === true)
+			if ($lock->locked === true)
 			{
-				echo JCache::getWorkarounds($data);
+				$this->cache->unlock($id);
+			}
+
+			if ($wrkarounds)
+			{
+				echo static::getWorkarounds($data);
 			}
 			else
 			{
 				// No workarounds, so all data is stored in one piece
-				echo isset($data) ? $data : null;
-			}
-
-			if ($locktest->locked == true)
-			{
-				$this->cache->unlock($id);
+				echo $data;
 			}
 
 			return true;
 		}
 
 		// No hit so we have to execute the view
-		if (method_exists($view, $method))
+		if (!method_exists($view, $method))
 		{
-			// If previous lock failed try again
-			if ($locktest->locked == false)
-			{
-				$locktest = $this->cache->lock($id);
-			}
+			return false;
+		}
 
-			// Capture and echo output
-			ob_start();
-			ob_implicit_flush(false);
+		if ($lock->locked === false)
+		{
+			// We can not store data because another process is in the middle of saving
 			$view->$method();
-			$data = ob_get_clean();
-			echo $data;
 
-			/*
-			 * For a view we have a special case.  We need to cache not only the output from the view, but the state
-			 * of the document head after the view has been rendered.  This will allow us to properly cache any attached
-			 * scripts or stylesheets or links or any other modifications that the view has made to the document object
-			 */
-			$cached = $wrkarounds == true ? JCache::setWorkarounds($data) : $data;
+			return false;
+		}
 
-			// Store the cache data
-			$this->cache->store(serialize($cached), $id);
+		// Capture and echo output
+		ob_start();
+		ob_implicit_flush(false);
+		$view->$method();
+		$data = ob_get_clean();
+		echo $data;
 
-			if ($locktest->locked == true)
-			{
-				$this->cache->unlock($id);
-			}
+		/*
+		 * For a view we have a special case.  We need to cache not only the output from the view, but the state
+		 * of the document head after the view has been rendered.  This will allow us to properly cache any attached
+		 * scripts or stylesheets or links or any other modifications that the view has made to the document object
+		 */
+		if ($wrkarounds)
+		{
+			$data = static::setWorkarounds($data);
+		}
+
+		// Store the cache data
+		$this->cache->store($data, $id);
+
+		if ($lock->locked === true)
+		{
+			$this->cache->unlock($id);
 		}
 
 		return false;
@@ -118,14 +121,14 @@ class JCacheControllerView extends JCacheController
 	/**
 	 * Generate a view cache ID.
 	 *
-	 * @param   object  &$view   The view object to cache output for
+	 * @param   object  $view    The view object to cache output for
 	 * @param   string  $method  The method name to cache for the view object
 	 *
 	 * @return  string  MD5 Hash
 	 *
 	 * @since   11.1
 	 */
-	protected function _makeId(&$view, $method)
+	protected function _makeId($view, $method)
 	{
 		return md5(serialize(array(JCache::makeId(), get_class($view), $method)));
 	}

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -35,7 +35,7 @@ class JCacheStorageFile extends JCacheStorage
 	public function __construct($options = array())
 	{
 		parent::__construct($options);
-		$this->_root = $options['cachebase'];
+		$this->_root = isset($options['cachebase']) ? $options['cachebase'] : JPATH_BASE . '/cache';
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/cache/JCacheStorageTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/JCacheStorageTest.php
@@ -59,7 +59,7 @@ class JCacheStorageTest extends TestCase
 		$this->setErrorCallback('JCacheStorageTest');
 		self::$actualError = array();
 
-		$this->object = new JCacheStorage;
+		$this->object = JCacheStorage::getInstance('file');
 
 		$this->checkStores();
 
@@ -266,20 +266,12 @@ class JCacheStorageTest extends TestCase
 			'Unexpected value for _locking.'
 		);
 
-		$config = JFactory::getConfig();
-		$lifetime = !is_null($options['lifetime']) ? $options['lifetime'] * 60 : $config->get('cachetime', 1) * 60;
+		$lifetime = !is_null($options['lifetime']) ? $options['lifetime'] * 60 : 60;
+
 		$this->assertThat(
 			$this->object->_lifetime,
-
-			// @todo remove: $this->equalTo(empty($options['lifetime']) ? $config->get('cachetime')*60 : $options['lifetime']*60),
 			$this->equalTo($lifetime),
 			'Unexpected value for _lifetime.'
-		);
-
-		$this->assertLessThan(
-			isset($config->cachetime) ? $config->cachetime : 900,
-			abs($this->object->_now - time()),
-			'Unexpected value for configuration lifetime.'
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/cache/JCacheTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/JCacheTest.php
@@ -190,12 +190,12 @@ class JCacheTest extends TestCase
 	{
 		$this->object = JCache::getInstance($handler, $options);
 
-		$caching = (bool) $this->object->options['caching'];
+		$caching = (bool) $this->object->getCaching();
 		$toggled = !$caching;
 		$this->object->setCaching($toggled);
 		$this->assertEquals(
 			$toggled,
-			$this->object->options['caching']
+			$this->object->getCaching()
 		);
 	}
 
@@ -254,7 +254,7 @@ class JCacheTest extends TestCase
 		$this->object->setLifeTime($lifetime);
 		$this->assertEquals(
 			$lifetime,
-			$this->object->options['lifetime']
+			$this->object->getLifetime()
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageMock.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageMock.php
@@ -19,19 +19,6 @@ class JCacheStorageMock extends JCacheStorage
 	private $_storage = array();
 
 	/**
-	 * Constructor
-	 *
-	 * @param   array  $options  optional parameters
-	 */
-	public function __construct($options = array())
-	{
-		parent::__construct($options);
-
-		$config = JFactory::getConfig();
-		$this->_hash = $config->get('secret');
-	}
-
-	/**
 	 * Get cached data by id and group
 	 *
 	 * @param   string   $id         The cache data id
@@ -46,12 +33,7 @@ class JCacheStorageMock extends JCacheStorage
 	{
 		$cache_id = $this->_getCacheId($id, $group);
 
-		if (isset($this->_storage[$id]))
-		{
-			return $this->_storage[$id];
-		}
-
-		return false;
+		return isset($this->_storage[$cache_id]) ? $this->_storage[$cache_id] : false;
 	}
 
 	/**
@@ -69,7 +51,9 @@ class JCacheStorageMock extends JCacheStorage
 	{
 		$cache_id = $this->_getCacheId($id, $group);
 
-		return ($this->_storage[$id] = $data);
+		$this->_storage[$cache_id] = $data;
+
+		return true;
 	}
 
 	/**
@@ -85,7 +69,8 @@ class JCacheStorageMock extends JCacheStorage
 	public function remove($id, $group)
 	{
 		$cache_id = $this->_getCacheId($id, $group);
-		unset($this->_storage[$id]);
+		unset($this->_storage[$cache_id]);
+		return true;
 	}
 
 	/**
@@ -102,7 +87,8 @@ class JCacheStorageMock extends JCacheStorage
 	 */
 	public function clean($group, $mode = null)
 	{
-		return ($this->_storage = array());
+		$this->_storage = array();
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12133.
### Summary of Changes
- Move serialize from JCacheController and subclasses to JCache get() and store() methods.
- Change JCacheController to more simpler.
- Remove JFactory::... stuff from almost all cache and storage instances.
- Move mothods getWorkarounds and setWorkarounds from JCache to JCacheController.
- Clean up code.
