### PR TITLE
[PoC] Table reorder for mysql, postgresql>=8.4, mssql

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1796,4 +1796,19 @@ abstract class JDatabaseQuery
 
 		return $this;
 	}
+
+	/**
+	 * Return number of the current row, starting from 1
+	 *
+	 * Usage:
+	 * $query->select($query->row_number() . ' AS ' . $db->quoteName('ordering'))
+	 *
+	 * @return  string  Returns sql expression
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function row_number()
+	{
+		return 'ROW_NUMBER() OVER ()';
+	}
 }

--- a/libraries/joomla/database/query/mysqli.php
+++ b/libraries/joomla/database/query/mysqli.php
@@ -141,4 +141,16 @@ class JDatabaseQueryMysqli extends JDatabaseQuery implements JDatabaseQueryLimit
 	{
 		return ' RAND() ';
 	}
+
+	/**
+	 * Return number of the current row, starting from 1
+	 *
+	 * @return  string  Returns sql expression
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function row_number()
+	{
+		return '(SELECT @a := @a + 1 FROM (SELECT @a := 0) ' . $this->quoteName('row_init') . ')';
+	}
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10567.

Do the same as at PR https://github.com/joomla/joomla-cms/pull/11184.

### Summary of Changes

For now it is only an idea that I tested on simple task in mysql.
Php should generate below query for mysql and postgresql.

MYSQL
```sql
UPDATE jos_content 
INNER JOIN ( SELECT `id` AS `primaryKey`, (
    SELECT @a := @a + 1 FROM (SELECT @a := 0) row_init) AS `rowNumber` 
    FROM jos_content WHERE ordering >= 0 ORDER BY ordering) AS sq ON id = sq.`primaryKey`
SET ordering = sq.rowNumber;
```

POSTGRESQL
```sql
UPDATE "jos_content" SET "ordering" = sq."rowNumber"
FROM ( 
    SELECT "id" AS "primaryKey", ROW_NUMBER() OVER () AS "rowNumber" 
    FROM "jos_content" WHERE "ordering" >= 0 ORDER BY "ordering") AS sq 
WHERE "id" = sq."primaryKey";
```

What do you thing about this?

### Testing Instructions
Not yet

### Links
http://stackoverflow.com/questions/3047789/how-to-enumerate-returned-rows-in-sql
http://stackoverflow.com/questions/4358613/using-window-functions-in-an-update-statement
http://sqlfiddle.com/#!15/6fc07/1
http://stackoverflow.com/questions/2446764/update-statement-with-inner-join-on-oracle