### PR TITLE
Use simpler db query in admin mod_menu, without GROUP BY

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -28,20 +28,22 @@ abstract class ModMenuHelper
 	 */
 	public static function getMenus()
 	{
-		$db     = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select('a.*, SUM(b.home) AS home')
-			->from('#__menu_types AS a')
-			->join('LEFT', '#__menu AS b ON b.menutype = a.menutype AND b.home != 0')
-			->select('b.language')
-			->join('LEFT', '#__languages AS l ON l.lang_code = language')
-			->select('l.image')
-			->select('l.sef')
-			->select('l.title_native')
+		$db = JFactory::getDbo();
+
+		// Search for home menu and language if exists
+		$subQuery = $db->getQuery(true)
+			->select('b.menutype, b.home, b.language, l.image, l.sef, l.title_native')
+			->from('#__menu AS b')
+			->leftJoin('#__languages AS l ON l.lang_code = b.language')
+			->where('b.home != 0')
 			->where('(b.client_id = 0 OR b.client_id IS NULL)');
 
-		// Sqlsrv change
-		$query->group('a.id, a.menutype, a.description, a.title, b.menutype,b.language,l.image,l.sef,l.title_native');
+		// Get all menu types with optional home menu and language
+		$query = $db->getQuery(true)
+			->select('a.id, a.asset_id, a.menutype, a.title, a.description, a.client_id')
+			->select('c.home, c.language, c.image, c.sef, c.title_native')
+			->from('#__menu_types AS a')
+			->leftJoin('(' . (string) $subQuery . ') c ON c.menutype = a.menutype');
 
 		$db->setQuery($query);
 


### PR DESCRIPTION
Pull Request for Issue # 12983.

### Summary of Changes
Create more simple and faster query which return the same result.

* return the same result
* do not use GROUP BY
* do not sort results - do not use SQL sort buffer memory
* skip buffer join, as on image below

### Testing Instructions

1. Go to backend and check whether menu items display the same list of items before and after patch.

For more advanced test you have to use a production db of joomla 3.6.5. 
Please try to test with multi language menu.
Go to phpmyadmin and check below queries:
- it should return the same number of rows, if not please add a comment. It may be related to #  12991

Before query:
```sql
SELECT /*! SQL_NO_CACHE */ a.*, SUM(b.home) AS home,b.language,l.image,l.sef,l.title_native
FROM j37_menu_types AS a
LEFT JOIN j37_menu AS b ON b.menutype = a.menutype AND b.home != 0
LEFT JOIN j37_languages AS l ON l.lang_code = language
WHERE (b.client_id = 0 OR b.client_id IS NULL)
GROUP BY a.id, a.menutype, a.description, a.title, b.menutype,b.language,l.image,l.sef,l.title_native
```

![amenu_before1](https://cloud.githubusercontent.com/assets/9054379/22829147/59e6706c-efa1-11e6-8446-1e30e4c798b9.jpeg)


After query:
```sql
SELECT /*! SQL_NO_CACHE */ a.id, a.asset_id, a.menutype, a.title, a.description,c.home, c.language, c.image, c.sef, c.title_native 
FROM j37_menu_types AS a 
LEFT JOIN ( 
    SELECT b.menutype, b.home, b.language, l.image, l.sef, l.title_native 
    FROM j37_menu AS b 
    LEFT JOIN j37_languages AS l ON l.lang_code = b.language 
    WHERE b.home != 0 AND (b.client_id = 0 OR b.client_id IS NULL)
) c ON c.menutype = a.menutype 
```

![amenu_after1](https://cloud.githubusercontent.com/assets/9054379/22829156/616416f0-efa1-11e6-8f5a-6876e70a1bcc.jpeg)


### Expected result
Works as before but for tables with more rows it should work faster.

### Actual result
Works.

### Documentation Changes Required
None
